### PR TITLE
🙈 Add package-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,3 +151,4 @@ $RECYCLE.BIN/
 dist
 public/index.html
 public/css/styles.min.css
+package-lock.json


### PR DESCRIPTION
`package-lock.json` added to `.gitignore` to prevent developers from accidentally using npm instead of yarn